### PR TITLE
call onEnd with nextTick in case component is unmounted

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ tweenState.Mixin = {
     var now = Date.now();
     state.tweenQueue.forEach(function(item) {
       if (now - item.initTime >= item.config.duration) {
-        item.config.onEnd && item.config.onEnd();
+        item.config.onEnd && setTimeout(item.config.onEnd, 0);
       }
     });
 


### PR DESCRIPTION
I had a situation where I unmounted a component in the onEnd function. I was invoking the animation from a container. Maybe weird, but it works.

Anyway, this still runs after onEnd is invoked, causing a race condition since the component is unmounted:

```
    this.setState({
      tweenQueue: newTweenQueue,
    });

    requestAnimationFrame(this._rafCb);
```

This PR should fix this!