### PR TITLE
Changed NPM BUILD command to now use production mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack -w -d"
+    "build": "webpack -p",
+    "start": "webpack -w -d"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously `npm build` built to development mode `-d` and added a watcher `-w` to the files in `webpack.config.js`. This caused bugs such as https://github.com/chenglou/react-tween-state/issues/38.

This PR changes the behavior so that `npm start` builds to development mode but `npm build` builds to production mode.