### PR TITLE
#47 Adds doc to README that ie9 and phantomjs need polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Bower:
 bower install react-tween-state
 ```
 
+**`react-tween-state` is incompatible with IE <= 9.0 and phantomjs. To polyfill use [raf (npm link)](https://www.npmjs.com/package/raf).**
+
 ## API
 
 Example usage:


### PR DESCRIPTION
Might be worth noting in the docs that a shim for requestAnimationFrame is necessary for older browser support and providing a shim in this situation.